### PR TITLE
Introducing Sugar.RegularExpressions, a regular expression library for Sugar.

### DIFF
--- a/Sugar.Data/Sugar.Data.Nougat.OSX.oxygene
+++ b/Sugar.Data/Sugar.Data.Nougat.OSX.oxygene
@@ -12,7 +12,7 @@
     <AssemblyName>Sugar.Data</AssemblyName>
     <DefaultUses>Foundation</DefaultUses>
     <StartupClass />
-    <DeploymentTargetVersion>10.6</DeploymentTargetVersion>
+    <DeploymentTargetVersion>10.7</DeploymentTargetVersion>
     <AllowLegacyOutParams>False</AllowLegacyOutParams>
     <CreateHeaderFile>False</CreateHeaderFile>
   </PropertyGroup>

--- a/Sugar.Tests/Main/WP8/Sugar.Echoes.WP8.Test.oxygene
+++ b/Sugar.Tests/Main/WP8/Sugar.Echoes.WP8.Test.oxygene
@@ -133,6 +133,7 @@
     <Compile Include="..\..\Tests\List.pas" />
     <Compile Include="..\..\Tests\Queue.pas" />
     <Compile Include="..\..\Tests\Random.pas" />
+    <Compile Include="..\..\Tests\RegularExpressions.pas" />
     <Compile Include="..\..\Tests\Stack.pas" />
     <Compile Include="..\..\Tests\String.pas" />
     <Compile Include="..\..\Tests\StringBuilder.pas" />

--- a/Sugar.Tests/Sugar.Cooper.Android.Test.oxygene
+++ b/Sugar.Tests/Sugar.Cooper.Android.Test.oxygene
@@ -115,6 +115,7 @@
     <Compile Include="Tests\MessageDigest.pas" />
     <Compile Include="Tests\Queue.pas" />
     <Compile Include="Tests\Random.pas" />
+    <Compile Include="Tests\RegularExpressions.pas" />
     <Compile Include="Tests\Stack.pas" />
     <Compile Include="Tests\String.pas" />
     <Compile Include="Tests\StringBuilder.pas" />

--- a/Sugar.Tests/Sugar.Cooper.Test.oxygene
+++ b/Sugar.Tests/Sugar.Cooper.Test.oxygene
@@ -74,6 +74,7 @@
     <Compile Include="Tests\MessageDigest.pas" />
     <Compile Include="Tests\Queue.pas" />
     <Compile Include="Tests\Random.pas" />
+    <Compile Include="Tests\RegularExpressions.pas" />
     <Compile Include="Tests\Stack.pas" />
     <Compile Include="Tests\String.pas" />
     <Compile Include="Tests\StringBuilder.pas" />

--- a/Sugar.Tests/Sugar.Echoes.Test.oxygene
+++ b/Sugar.Tests/Sugar.Echoes.Test.oxygene
@@ -87,6 +87,7 @@
     <Compile Include="Tests\MessageDigest.pas" />
     <Compile Include="Tests\Queue.pas" />
     <Compile Include="Tests\Random.pas" />
+    <Compile Include="Tests\RegularExpressions.pas" />
     <Compile Include="Tests\Stack.pas" />
     <Compile Include="Tests\String.pas" />
     <Compile Include="Tests\StringBuilder.pas" />

--- a/Sugar.Tests/Sugar.Echoes.WinRT.Test.oxygene
+++ b/Sugar.Tests/Sugar.Echoes.WinRT.Test.oxygene
@@ -130,6 +130,7 @@
     <Compile Include="Tests\MessageDigest.pas" />
     <Compile Include="Tests\Queue.pas" />
     <Compile Include="Tests\Random.pas" />
+    <Compile Include="Tests\RegularExpressions.pas" />
     <Compile Include="Tests\Stack.pas" />
     <Compile Include="Tests\String.pas" />
     <Compile Include="Tests\StringBuilder.pas" />

--- a/Sugar.Tests/Sugar.Nougat.OSX.Test.oxygene
+++ b/Sugar.Tests/Sugar.Nougat.OSX.Test.oxygene
@@ -72,6 +72,7 @@
     <Compile Include="Tests\MessageDigest.pas" />
     <Compile Include="Tests\Queue.pas" />
     <Compile Include="Tests\Random.pas" />
+    <Compile Include="Tests\RegularExpressions.pas" />
     <Compile Include="Tests\Stack.pas" />
     <Compile Include="Tests\String.pas" />
     <Compile Include="Tests\StringBuilder.pas" />

--- a/Sugar.Tests/Sugar.Nougat.iOS.Test.oxygene
+++ b/Sugar.Tests/Sugar.Nougat.iOS.Test.oxygene
@@ -75,6 +75,7 @@
     <Compile Include="Tests\MessageDigest.pas" />
     <Compile Include="Tests\Queue.pas" />
     <Compile Include="Tests\Random.pas" />
+    <Compile Include="Tests\RegularExpressions.pas" />
     <Compile Include="Tests\Stack.pas" />
     <Compile Include="Tests\String.pas" />
     <Compile Include="Tests\StringBuilder.pas" />

--- a/Sugar.Tests/Tests/RegularExpressions.pas
+++ b/Sugar.Tests/Tests/RegularExpressions.pas
@@ -1,0 +1,157 @@
+namespace Sugar.Test;
+
+interface
+
+uses
+  Sugar,
+  Sugar.Collections,
+  Sugar.RegularExpressions,
+  RemObjects.Elements.EUnit;
+
+type
+  RegularExpressionsTest = public class (Test)
+  private
+    const ContactNumbers: String = "Voice: (425) 555-1234. Fax: (206) 555-5678.";
+    const PhoneNumberPattern: String = "\((\d{3})\) (\d{3}-\d{4})";
+    const PhoneNumberTypePattern: String = "([a-zA-Z]+):";
+  public
+    method FindMatchesSequentially;
+    method FindMatchesAllAtOnce;
+    method IgnoreCase;
+    method IgnoreWhitespace;
+    method Multiline;
+    method ReplaceMatches;
+    method Singleline;
+  end;
+
+implementation
+
+method RegularExpressionsTest.FindMatchesSequentially;
+begin
+  var FirstMatch: Match := new Regex(PhoneNumberPattern).FindFirstMatch(ContactNumbers);
+  Assert.IsNotNil(FirstMatch);
+  Assert.AreEqual(FirstMatch.Start,  7);
+  Assert.AreEqual(FirstMatch.End,    20);
+  Assert.AreEqual(FirstMatch.Length, 14);
+  Assert.AreEqual(FirstMatch.Text,   "(425) 555-1234");
+  Assert.AreEqual(FirstMatch.Groups.Count, 2);
+  Assert.AreEqual(FirstMatch.Groups.Item[0].Start,  8);
+  Assert.AreEqual(FirstMatch.Groups.Item[0].End,    10);
+  Assert.AreEqual(FirstMatch.Groups.Item[0].Length, 3);
+  Assert.AreEqual(FirstMatch.Groups.Item[0].Text,   "425");
+  Assert.AreEqual(FirstMatch.Groups.Item[1].Start,  13);
+  Assert.AreEqual(FirstMatch.Groups.Item[1].End,    20);
+  Assert.AreEqual(FirstMatch.Groups.Item[1].Length, 8);
+  Assert.AreEqual(FirstMatch.Groups.Item[1].Text,   "555-1234");
+
+  var SecondMatch: Match := FirstMatch.FindNext();
+  Assert.IsNotNil(SecondMatch);
+  Assert.AreEqual(SecondMatch.Start,  28);
+  Assert.AreEqual(SecondMatch.End,    41);
+  Assert.AreEqual(SecondMatch.Length, 14);
+  Assert.AreEqual(SecondMatch.Text,   "(206) 555-5678");
+  Assert.AreEqual(SecondMatch.Groups.Count, 2);
+  Assert.AreEqual(SecondMatch.Groups.Item[0].Start,  29);
+  Assert.AreEqual(SecondMatch.Groups.Item[0].End,    31);
+  Assert.AreEqual(SecondMatch.Groups.Item[0].Length, 3);
+  Assert.AreEqual(SecondMatch.Groups.Item[0].Text,   "206");
+  Assert.AreEqual(SecondMatch.Groups.Item[1].Start,  34);
+  Assert.AreEqual(SecondMatch.Groups.Item[1].End,    41);
+  Assert.AreEqual(SecondMatch.Groups.Item[1].Length, 8);
+  Assert.AreEqual(SecondMatch.Groups.Item[1].Text,   "555-5678");
+
+  Assert.IsNil(SecondMatch.FindNext());
+end;
+
+method RegularExpressionsTest.FindMatchesAllAtOnce;
+begin
+  var Matches: List<Match> := new Regex(PhoneNumberTypePattern).FindMatches(ContactNumbers);
+  Assert.AreEqual(Matches.Count, 2);
+
+  Assert.AreEqual(Matches.Item[0].Start,  0);
+  Assert.AreEqual(Matches.Item[0].End,    5);
+  Assert.AreEqual(Matches.Item[0].Length, 6);
+  Assert.AreEqual(Matches.Item[0].Text,   "Voice:");
+  Assert.AreEqual(Matches.Item[0].Groups.Count, 1);
+  Assert.AreEqual(Matches.Item[0].Groups.Item[0].Start,  0);
+  Assert.AreEqual(Matches.Item[0].Groups.Item[0].End,    4);
+  Assert.AreEqual(Matches.Item[0].Groups.Item[0].Length, 5);
+  Assert.AreEqual(Matches.Item[0].Groups.Item[0].Text,   "Voice");
+
+  Assert.AreEqual(Matches.Item[1].Start,  23);
+  Assert.AreEqual(Matches.Item[1].End,    26);
+  Assert.AreEqual(Matches.Item[1].Length, 4);
+  Assert.AreEqual(Matches.Item[1].Text,   "Fax:");
+  Assert.AreEqual(Matches.Item[1].Groups.Count, 1);
+  Assert.AreEqual(Matches.Item[1].Groups.Item[0].Start,  23);
+  Assert.AreEqual(Matches.Item[1].Groups.Item[0].End,    25);
+  Assert.AreEqual(Matches.Item[1].Groups.Item[0].Length, 3);
+  Assert.AreEqual(Matches.Item[1].Groups.Item[0].Text,   "Fax");
+end;
+
+method RegularExpressionsTest.IgnoreCase;
+const
+  Pattern: String = "FAX: (" + PhoneNumberPattern + ")";
+begin
+  var CaseSensitiveRegex := new Regex(Pattern);
+  Assert.IsFalse(CaseSensitiveRegex.IsMatch(ContactNumbers));
+
+  var CaseInsensitiveRegex := new Regex(Pattern, RegexOptions.IgnoreCase);
+  Assert.IsTrue(CaseInsensitiveRegex.IsMatch(ContactNumbers));
+end;
+
+method RegularExpressionsTest.IgnoreWhitespace;
+begin
+  var RegexWithWhitespace := new Regex(PhoneNumberPattern);
+  Assert.IsTrue(RegexWithWhitespace.IsMatch(ContactNumbers));
+  Assert.IsFalse(RegexWithWhitespace.IsMatch(ContactNumbers.Replace(" ", "")));
+
+  var RegexWithoutWhitespace := new Regex(PhoneNumberPattern, RegexOptions.IgnoreWhitespace);
+  Assert.IsFalse(RegexWithoutWhitespace.IsMatch(ContactNumbers));
+  Assert.IsTrue(RegexWithoutWhitespace.IsMatch(ContactNumbers.Replace(" ", "")));
+end;
+
+method RegularExpressionsTest.Multiline;
+const
+  DelimitedPhoneNumberPattern: String = "^" + PhoneNumberPattern + "$";
+begin
+  var MultilineContactNumbers: String := ContactNumbers.Replace(": ", ":"#10).Replace(". ", #10);
+
+  var NonMultilineRegex := new Regex(DelimitedPhoneNumberPattern);
+  Assert.IsFalse(NonMultilineRegex.IsMatch(ContactNumbers));
+  Assert.IsFalse(NonMultilineRegex.IsMatch(MultilineContactNumbers));
+
+  var MultilineRegex := new Regex(DelimitedPhoneNumberPattern, RegexOptions.Multiline);
+  Assert.IsFalse(MultilineRegex.IsMatch(ContactNumbers));
+  Assert.IsTrue(MultilineRegex.IsMatch(MultilineContactNumbers));
+end;
+
+method RegularExpressionsTest.ReplaceMatches;
+const
+  FaxPattern: String = "Fax:";
+  VoicePattern: String = "Voice:";
+begin
+  var FaxRegex: Regex := new Regex(FaxPattern);
+  var VoiceRegex: Regex := new Regex(VoicePattern);
+  var AlteredContactNumbers: String := VoiceRegex.ReplaceMatches(ContactNumbers, FaxPattern);
+
+  Assert.AreEqual(FaxRegex.FindMatches(ContactNumbers).Count, 1);
+  Assert.AreEqual(VoiceRegex.FindMatches(ContactNumbers).Count, 1);
+  Assert.AreEqual(FaxRegex.FindMatches(AlteredContactNumbers).Count, 2);
+  Assert.AreEqual(VoiceRegex.FindMatches(AlteredContactNumbers).Count, 0);
+end;
+
+method RegularExpressionsTest.Singleline;
+begin
+  var MultilineContactNumbers: String := ContactNumbers.Replace(": ", ":"#10).Replace(". ", #10);
+
+  var NonSinglelineRegex := new Regex(PhoneNumberTypePattern + ".");
+  Assert.IsTrue(NonSinglelineRegex.IsMatch(ContactNumbers));
+  Assert.IsFalse(NonSinglelineRegex.IsMatch(MultilineContactNumbers));
+
+  var SinglelineRegex := new Regex(PhoneNumberTypePattern + ".", RegexOptions.Singleline);
+  Assert.IsTrue(SinglelineRegex.IsMatch(ContactNumbers));
+  Assert.IsTrue(SinglelineRegex.IsMatch(MultilineContactNumbers));
+end;
+
+end.

--- a/Sugar/RegularExpressions/Group.pas
+++ b/Sugar/RegularExpressions/Group.pas
@@ -1,0 +1,29 @@
+﻿namespace Sugar.RegularExpressions;
+
+interface
+
+type
+  &Group = public class
+  protected
+    fLength: Integer;
+    fStart: Integer;
+    fText: String;
+  public
+    constructor(aStart: Integer; aLength: Integer; aText: String);
+
+    property &End: Integer read fStart + fLength - 1;
+    property Length: Integer read fLength;
+    property Start: Integer read fStart;
+    property Text: String read fText;
+  end;
+
+implementation
+
+constructor &Group(aStart: Integer; aLength: Integer; aText: String);
+begin
+  fLength := aLength;
+  fStart := aStart;
+  fText := aText;
+end;
+
+end.

--- a/Sugar/RegularExpressions/Match.pas
+++ b/Sugar/RegularExpressions/Match.pas
@@ -1,0 +1,138 @@
+﻿namespace Sugar.RegularExpressions;
+
+interface
+
+uses
+  Sugar.Collections;
+
+type
+  Match = public class {$IF     COOPER}mapped to java.util.regex.Matcher
+                       {$ELSEIF ECHOES}mapped to System.Text.RegularExpressions.Match{$ENDIF}
+  protected
+    {$IF NOUGAT}
+    fInput: String;
+    fMatch: NSTextCheckingResult;
+    {$ENDIF}
+    method GetEnd: Integer;
+    method GetGroups: List<&Group>;
+    method GetLength: Integer;
+    method GetStart: Integer;
+    method GetText: String;
+  public
+    {$IF NOUGAT}
+    constructor(PlatformMatch: NSTextCheckingResult; Input: String);
+    {$ENDIF}
+    method FindNext: Match;
+
+    property &End: Integer read GetEnd;
+    property Groups: List<&Group> read GetGroups;
+    property Length: Integer read GetLength;
+    property Start: Integer read GetStart;
+    property Text: String read GetText;
+end;
+
+implementation
+
+{$IF NOUGAT}
+constructor Match(PlatformMatch: NSTextCheckingResult; Input: String);
+begin
+  fMatch := PlatformMatch;
+  fInput := Input;
+end;
+{$ENDIF}
+
+method Match.FindNext: Match;
+begin
+  {$IF COOPER}
+  exit if mapped.find() then mapped else nil;
+  {$ELSEIF ECHOES}
+  var NextMatch: System.Text.RegularExpressions.Match := mapped.NextMatch();
+  exit if NextMatch.Success then NextMatch else nil;
+  {$ELSEIF NOUGAT}
+  var Offset: Integer := fMatch.range.location + fMatch.range.length;
+  var NextMatch: NSTextCheckingResult := fMatch.regularExpression.
+    firstMatchInString(fInput)
+    options(NSMatchingOptions(0))
+    range(NSMakeRange(Offset, fInput.length - Offset));
+  exit if NextMatch <> nil then new Match(NextMatch, fInput) else nil;
+  {$ENDIF}
+end;
+
+method Match.GetEnd: Integer;
+begin
+  {$IF COOPER}
+  exit mapped.end() - 1;
+  {$ELSEIF ECHOES}
+  exit mapped.Index + mapped.Length - 1;
+  {$ELSEIF NOUGAT}
+  exit fMatch.range.location + fMatch.range.length - 1;
+  {$ENDIF}
+end;
+
+method Match.GetGroups: List<&Group>;
+begin
+  var GroupCount: Integer;
+  var Results: List<&Group> := new List<&Group>();
+
+  {$IF COOPER}
+  GroupCount := mapped.groupCount() + 1;
+  {$ELSEIF ECHOES}
+  GroupCount := mapped.Groups.Count;
+  {$ELSEIF NOUGAT}
+  GroupCount := fMatch.numberOfRanges;
+  {$ENDIF}
+
+  for I: Integer := 1 to GroupCount - 1 do
+    Results.Add(
+      {$IF COOPER}
+      if mapped.group(I) <> nil then
+        new &Group(mapped.start(I), mapped.end(I) - mapped.start(I), mapped.group(I))
+      {$ELSEIF ECHOES}
+      if mapped.Groups.Item[I].Success then
+        new &Group(mapped.Groups.Item[I].Index, mapped.Groups.Item[I].Length, mapped.Groups.Item[I].Value)
+      {$ELSEIF NOUGAT}
+      if fMatch.rangeAtIndex(I).location <> NSNotFound then
+        new &Group(fMatch.rangeAtIndex(I).location,
+                   fMatch.rangeAtIndex(I).length,
+                   fInput.substringWithRange(fMatch.rangeAtIndex(I)))
+      {$ENDIF}
+      else nil
+    );
+
+  exit Results;
+end;
+
+method Match.GetLength: Integer;
+begin
+  {$IF COOPER}
+  exit mapped.end() - mapped.start();
+  {$ELSEIF ECHOES}
+  exit mapped.Length;
+  {$ELSEIF NOUGAT}
+  exit fMatch.range.length;
+  {$ENDIF}
+end;
+
+method Match.GetStart: Integer;
+begin
+  {$IF COOPER}
+  exit mapped.start();
+  {$ELSEIF ECHOES}
+  exit mapped.Index;
+  {$ELSEIF NOUGAT}
+  exit fMatch.range.location;
+  {$ENDIF}
+end;
+
+method Match.GetText: String;
+begin
+  {$IF COOPER}
+  exit mapped.group();
+  {$ELSEIF ECHOES}
+  exit mapped.Value;
+  {$ELSEIF NOUGAT}
+  exit fInput.substringWithRange(fMatch.range);
+  {$ENDIF}
+end;
+
+end.

--- a/Sugar/RegularExpressions/Regex.pas
+++ b/Sugar/RegularExpressions/Regex.pas
@@ -1,0 +1,139 @@
+﻿namespace Sugar.RegularExpressions;
+
+interface
+
+uses
+  Sugar.Collections;
+
+type
+  RegexOptions = public flags (IgnoreCase, IgnoreWhitespace, Multiline, Singleline);
+
+  Regex = public class mapped to {$IF     COOPER}java.util.regex.Pattern
+                                 {$ELSEIF ECHOES}System.Text.RegularExpressions.Regex
+                                 {$ELSEIF NOUGAT}NSRegularExpression{$ENDIF}
+  private
+    class method OptionsToBitfield(PatternOptions: RegexOptions): Integer;
+  public
+    constructor(Pattern: String; PatternOptions: RegexOptions);
+    constructor(Pattern: String);
+    method FindFirstMatch(Input: String): Match;
+    method FindMatches(Input: String): List<Match>;
+    method IsMatch(Input: String): Boolean;
+    method ReplaceMatches(Input: String; Replacement: String): String;
+  end;
+
+implementation
+
+constructor Regex(Pattern: String; PatternOptions: RegexOptions);
+begin
+  var Bitfield: Integer := OptionsToBitfield(PatternOptions);
+
+  {$IF COOPER}
+  exit java.util.regex.Pattern.compile(Pattern, Bitfield);
+  {$ELSEIF ECHOES}
+  exit new System.Text.RegularExpressions.Regex(Pattern, System.Text.RegularExpressions.RegexOptions(Bitfield));
+  {$ELSEIF NOUGAT}
+  var Error: NSError;
+  exit NSRegularExpression.regularExpressionWithPattern(Pattern)
+                           options(NSRegularExpressionOptions(Bitfield))
+                           error(var Error);
+  {$ENDIF}
+end;
+
+constructor Regex(Pattern: String);
+begin
+  constructor(Pattern, RegexOptions(0));
+end;
+
+method Regex.FindFirstMatch(Input: String): Match;
+begin
+  {$IF COOPER}
+  var Matcher: java.util.regex.Matcher := mapped.matcher(Input);
+  exit if Matcher.find() then Matcher else nil;
+  {$ELSEIF ECHOES}
+  var FirstMatch: System.Text.RegularExpressions.Match := mapped.Match(Input);
+  exit if FirstMatch.Success then FirstMatch else nil;
+  {$ELSEIF NOUGAT}
+  var FirstMatch: NSTextCheckingResult := mapped.firstMatchInString(Input)
+                                                 options(NSMatchingOptions(0))
+                                                 range(NSMakeRange(0, Input.length));
+  exit if FirstMatch <> nil then new Match(FirstMatch, Input) else nil;
+  {$ENDIF}
+end;
+
+method Regex.FindMatches(Input: String): List<Match>;
+begin
+  var Matches: List<Match> := new List<Match>();
+
+  {$IF COOPER}
+  var Matcher: java.util.regex.Matcher := mapped.matcher(Input);
+  while (Matcher.find()) do
+    Matches.Add(Match(Matcher.toMatchResult()));
+  {$ELSEIF ECHOES}
+  var PlatformMatches: System.Text.RegularExpressions.MatchCollection := mapped.Matches(Input);
+  for PlatformMatch in PlatformMatches do
+    Matches.Add(Match(PlatformMatch));
+  {$ELSEIF NOUGAT}
+  var PlatformMatches: NSArray := mapped.matchesInString(Input)
+                                         options(NSMatchingOptions(0))
+                                         range(NSMakeRange(0, Input.length));
+  for PlatformMatch in PlatformMatches do
+    Matches.Add(new Match(PlatformMatch, Input));
+  {$ENDIF}
+
+  exit Matches;
+end;
+
+method Regex.IsMatch(Input: String): Boolean;
+begin
+  {$IF COOPER}
+  exit mapped.matcher(Input).find();
+  {$ELSEIF ECHOES}
+  exit mapped.IsMatch(Input);
+  {$ELSEIF NOUGAT}
+  var MatchCount: Integer := mapped.numberOfMatchesInString(Input)
+                                    options(NSMatchingOptions(0))
+                                    range(NSMakeRange(0, Input.length));
+  exit MatchCount > 0;
+  {$ENDIF}
+end;
+
+class method Regex.OptionsToBitfield(PatternOptions: RegexOptions): Integer;
+begin
+  var Bitfield: Integer := 0;
+
+  if RegexOptions.IgnoreCase in PatternOptions then Bitfield := Bitfield or
+    {$IF     COOPER}java.util.regex.Pattern.CASE_INSENSITIVE
+    {$ELSEIF ECHOES}System.Text.RegularExpressions.RegexOptions.IgnoreCase
+    {$ELSEIF NOUGAT}NSRegularExpressionOptions.NSRegularExpressionCaseInsensitive{$ENDIF};
+  if RegexOptions.IgnoreWhitespace in PatternOptions then Bitfield := Bitfield or
+    {$IF     COOPER}java.util.regex.Pattern.COMMENTS
+    {$ELSEIF ECHOES}System.Text.RegularExpressions.RegexOptions.IgnorePatternWhitespace
+    {$ELSEIF NOUGAT}NSRegularExpressionOptions.NSRegularExpressionAllowCommentsAndWhitespace{$ENDIF};
+  if RegexOptions.Multiline in PatternOptions then Bitfield := Bitfield or
+    {$IF     COOPER}java.util.regex.Pattern.MULTILINE
+    {$ELSEIF ECHOES}System.Text.RegularExpressions.RegexOptions.Multiline
+    {$ELSEIF NOUGAT}NSRegularExpressionOptions.NSRegularExpressionAnchorsMatchLines{$ENDIF};
+  if RegexOptions.Singleline in PatternOptions then Bitfield := Bitfield or
+    {$IF     COOPER}java.util.regex.Pattern.DOTALL
+    {$ELSEIF ECHOES}System.Text.RegularExpressions.RegexOptions.Singleline
+    {$ELSEIF NOUGAT}NSRegularExpressionOptions.NSRegularExpressionDotMatchesLineSeparators{$ENDIF};
+
+  exit Bitfield;
+end;
+
+method Regex.ReplaceMatches(Input: String; Replacement: String): String;
+begin
+  {$IF COOPER}
+  exit mapped.matcher(Input).replaceAll(Replacement);
+  {$ELSEIF ECHOES}
+  exit mapped.Replace(Input, Replacement);
+  {$ELSEIF NOUGAT}
+  exit mapped.stringByReplacingMatchesInString(Input)
+              options(NSMatchingOptions(0))
+              range(NSMakeRange(0, Input.length))
+              withTemplate(Replacement);
+  {$ENDIF}
+end;
+
+end.

--- a/Sugar/Sugar.Nougat.OSX.oxygene
+++ b/Sugar/Sugar.Nougat.OSX.oxygene
@@ -11,7 +11,7 @@
     <ProjectGuid>{ab7ab88b-2370-43bf-844b-54d015da9e57}</ProjectGuid>
     <AssemblyName>Sugar</AssemblyName>
     <DefaultUses>Foundation</DefaultUses>
-    <DeploymentTargetVersion>10.6</DeploymentTargetVersion>
+    <DeploymentTargetVersion>10.7</DeploymentTargetVersion>
     <AllowLegacyOutParams>False</AllowLegacyOutParams>
     <CreateHeaderFile>False</CreateHeaderFile>
   </PropertyGroup>

--- a/Sugar/Sugar.Shared.projitems
+++ b/Sugar/Sugar.Shared.projitems
@@ -72,6 +72,9 @@
     <Compile Include="Reflection\MethodInfo.pas" />
     <Compile Include="Reflection\ParameterInfo.pas" />
     <Compile Include="Reflection\Type.pas" />
+    <Compile Include="RegularExpressions\Group.pas" />
+    <Compile Include="RegularExpressions\Match.pas" />
+    <Compile Include="RegularExpressions\Regex.pas" />
     <Compile Include="String.pas" />
     <Compile Include="StringBuilder.pas" />
     <Compile Include="StringFormatter.pas" />
@@ -111,6 +114,7 @@
     <Folder Include="$(MSBuildThisFileDirectory)IO\" />
     <Folder Include="$(MSBuildThisFileDirectory)JSON\" />
     <Folder Include="$(MSBuildThisFileDirectory)Reflection\" />
+    <Folder Include="$(MSBuildThisFileDirectory)RegularExpressions\" />
     <Folder Include="$(MSBuildThisFileDirectory)Threading\" />
     <Folder Include="$(MSBuildThisFileDirectory)XML\" />
   </ItemGroup>


### PR DESCRIPTION
The API is modeled after .NET's, with a basic use case being as follows:

- Create an instance of `Regex` with a given pattern and, optionally, pattern options. The pattern is compiled and becomes immutable for the life of the `Regex` object.
- To determine whether the pattern matches a given string, call `IsMatch()` on the `Regex` object. This returns a boolean.
- To replace any and all matches of the pattern in a given string with another string, call `ReplaceMatches()` on the `Regex` object.
- To find all matches of the pattern in a given string at once, call `FindMatches()` on the `Regex` object. Any matches are returned as a list of `Match` objects.
- To find only the first match of the pattern in a given string, call `FindFirstMatch()` on the `Regex` object. The match—if any—is returned as an instance of `Match`, and further matches may be found by successively calling `FindNext()` on each `Match` object.
- To retrieve the matched portion of the input string, read the `Text` property of a `Match` object. Other properties (`Start`, `End`, `Length`) indicate where in the input string the match occurred.
- If the pattern contained any capturing groups, matches on those groups may be accessed via the `Groups` property of a `Match` object, which consists of a list of `Group` objects.
- `Group` exposes `Start`, `End`, `Length`, and `Text` properties analogous to those of `Match`.